### PR TITLE
Implement Error Handling in {send,recv}_file

### DIFF
--- a/src/proj.h
+++ b/src/proj.h
@@ -2,6 +2,7 @@
 #include <stdlib.h>     // exit
 #include <string.h>     // strcmp
 #include <stdbool.h>    // true, false
+#include <stdint.h>     // uint32_t
 
 #include <unistd.h>     // read, write, close
 
@@ -26,27 +27,32 @@
 #define MAX_DATA_SIZE 1024
 
 
+////// CMD Constants //////
+
+typedef uint32_t MsgType;
+
 // First four hex digits chosen to make debugging easier (should
 // we need to read hex dumps). Second four digits specify the size
 // of the assocated struct. Assumes sizeof all the structs are less
 // than 16^4 bytes.
 
 // Sending file from CLIENT to SERVER
-#define CMD_SEND (0xAAAA0000 | sizeof(struct send_msg))
+#define CMD_SEND (MsgType) (0xAAAA0000u | sizeof(struct send_msg))
 // Sending file from SERVER to CLIENT
-#define CMD_RECV (0xBBBB0000 | sizeof(struct send_msg))
+#define CMD_RECV (MsgType) (0xBBBB0000u | sizeof(struct send_msg))
 // Sent by server to client as acknowledgement
-#define CMD_RESP (0xCCCC0000 | sizeof(struct resp_msg))
+#define CMD_RESP (MsgType) (0xCCCC0000u | sizeof(struct resp_msg))
 // Header for a data message
-#define CMD_DATA (0xDDDD0000 | sizeof(struct data_msg))
+#define CMD_DATA (MsgType) (0xDDDD0000u | sizeof(struct data_msg))
 
 // Macro that extracts the `sizeof` the associated struct from
 // a `msg_type` value.
-#define MSG_SIZE(msg_type) ((msg_type) & 0x0000FFFF)
+#define MSG_SIZE(msg_type) (size_t) ((msg_type) & 0x0000FFFFu)
 
 
 // To be used in the `status` field of a resp_msg structure.
 #define OK 0
+
 
 // Used by client to tell server either:
 //      "I will be sending a file"
@@ -55,7 +61,7 @@ struct send_msg {
 
     // Either CMD_SEND or CMD_RECV
     // Note: defined in proj.h
-    int msg_type;
+    MsgType msg_type;
 
     // Size (in bytes) of file to be sent (or 0 if not applicable)
     int file_size;
@@ -68,7 +74,7 @@ struct send_msg {
 struct resp_msg {
 
     // Either CMD_SEND or CMD_RECV
-    int msg_type;
+    MsgType msg_type;
 
     // Either OK or else some value of `errno`
     // Note: `OK` is defined as 0 in proj.h
@@ -82,7 +88,7 @@ struct resp_msg {
 struct data_msg {
     
     // Always CMD_DATA
-    int msg_type;
+    MsgType msg_type;
 
     // Number of bytes of `buffer` that are actually filled
     int data_leng;
@@ -93,7 +99,7 @@ struct data_msg {
 
 
 struct tag_msg {
-    int msg_type;
+    MsgType msg_type;
 };
 
 // Generic message type. Could be either a send, resp, or data
@@ -107,6 +113,7 @@ union any_msg {
     // Not used except when switching on `msg_type`.
     struct tag_msg any;
 };
+
 
 ////// Common Functions //////
 
@@ -131,7 +138,7 @@ bool locate_file(const char *filename, int *fd);
 // The argument `msg_type` accepts the type of the message you expect
 // to recieve.
 void send_msg(int sd, union any_msg *to_send);
-void recv_msg(int sd, union any_msg *receiving_buf, int msg_type);
+void recv_msg(int sd, union any_msg *receiving_buf, MsgType msg_type);
 
 // Specialized send/recv functions for sending data messages.
 // Only use with `struct data_msg` pointers, don't cast!

--- a/src/proj.h
+++ b/src/proj.h
@@ -14,8 +14,7 @@
 #include <netinet/in.h> // struct sockaddr_in
 #include <arpa/inet.h>  // htons, inet_pton
 
-
-extern int errno;
+#include <errno.h>      // errno
 
 // Define permissions for writing files.
 #define OPEN_PERMS 0644
@@ -143,10 +142,23 @@ void recv_data(int sd, struct data_msg *receiving_buf);
 // Sends the file opened under file descriptor `fd` accross the
 // network to the peer located by socket descriptor `sd`.
 // Assumes both arguments have been opened already.
+// Note: Does NOT close the file descriptor when done.
+//
+// If an error occurs while `send_file` is reading the file,
+// the function will send a `data_msg` with the `data_leng`
+// field set to the negative of `errno`. The file transmission
+// will then halt.
 void send_file(int sd, int fd);
 
 // Recieves a file from the peer located by socket descriptor `sd`
 // and saves it to the file called `filename`. Assumes that the
 // socket has been opened.
+//
+// If the sender encounters an error, a `data_msg` will be sent
+// with the `data_leng` field set to the negative of the `errno`
+// encountered. The reciever will then print out the associated
+// error message and then stop recv'ing messages from the socket.
+// At this point, since the output file would be incomplete, it
+// will be deleted.
 void recv_file(int sd, char *filename, int file_size);
 

--- a/src/sendrecv.c
+++ b/src/sendrecv.c
@@ -91,7 +91,7 @@ bool locate_file(const char *filename, int *fd)
 
 void send_msg(int sd, union any_msg *to_send)
 {
-    int type = to_send->any.msg_type;
+    MsgType type = to_send->any.msg_type;
     
     bool valid =
         type == CMD_SEND ||
@@ -115,7 +115,7 @@ void send_msg(int sd, union any_msg *to_send)
 
 }
 
-void recv_msg(int sd, union any_msg *receiving_buf, int msg_type)
+void recv_msg(int sd, union any_msg *receiving_buf, MsgType msg_type)
 {
     int bytes_expected = MSG_SIZE(msg_type);
     int bytes_recvd = recv(sd, (void *) receiving_buf, bytes_expected, 0);

--- a/src/sendrecv.c
+++ b/src/sendrecv.c
@@ -274,7 +274,16 @@ void recv_file(int sd, char *filename, int file_size)
                "peer");
         fprintf(stderr, "Aborting file transfer.\n");
 
-        // Delete output file (will happen when `fd` is closed).
+        // Deletion of output file (will happen when `fd` is closed).
+        if (remove(filename) == -1) {
+            perror("recv_file: Removal of incomplete output file failed");
+        }
+    }
+    else if (file_size != total_bytes) {
+        fprintf(stderr, "recv_file: File recv'd has different size than "
+                "expected. Removing incomplete output file...\n");
+
+        // Deletion of output file (will happen when `fd` is closed).
         if (remove(filename) == -1) {
             perror("recv_file: Removal of incomplete output file failed");
         }

--- a/src/sendrecv.c
+++ b/src/sendrecv.c
@@ -117,7 +117,7 @@ void send_msg(int sd, union any_msg *to_send)
 
 void recv_msg(int sd, union any_msg *receiving_buf, int msg_type)
 {
-    int bytes_expected = MSG_SIZE(msg_type);    
+    int bytes_expected = MSG_SIZE(msg_type);
     int bytes_recvd = recv(sd, (void *) receiving_buf, bytes_expected, 0);
 
     if (bytes_recvd == 0) {
@@ -151,8 +151,6 @@ void recv_data(int sd, struct data_msg *receiving_buf)
     recv_msg(sd, (union any_msg *) receiving_buf, CMD_DATA);
 }
 
-// TODO: Impl error handling and send resp_msg {.status=ERROR} when
-// bad stuff does happen.
 void send_file(int sd, int fd)
 {
     struct data_msg msg = {
@@ -163,66 +161,126 @@ void send_file(int sd, int fd)
     const int buf_size = sizeof(msg.buffer);
 
     while ((msg.data_leng = read(fd, msg.buffer, buf_size)) != 0) {
-        send_data(sd, &msg);
+
+        if (msg.data_leng == -1) { // Must inform peer.
+            msg.data_leng = -errno; // Send errno to peer.
+            perror("send_msg: an error occured while reading file");
+            fprintf(stderr, "Aborting file transmission.\n");
+            break;
+        }
+
+        send_msg(sd, (union any_msg *) &msg);
         printf("Sent %d bytes from file\n", msg.data_leng);
     }
 
-    // After while loop, msg.data_leng == 0.
+    // If all went well, msg.data_leng == 0 here.
     // Send final data message with nothing in buffer to
     // signal end of transmission.
-    send_data(sd, &msg);
+    //
+    // If an error occurred, msg.data_leng == -errno.
+    // This will be caught and handled by `recv_file`.
+    send_msg(sd, (union any_msg *) &msg);
 }
 
 
-// TODO: Impl error handling for when some resp_msg {.status=ERROR}
-// is sent.
-void recv_file(int sd, char *filename, int file_size)
+// Exits with error message if error occurs.
+// Pass the `callee` parameter the value `__func__` for better error info.
+static int safe_open_for_write(const char *filename, const char *callee)
 {
-    struct data_msg buf;
-    int total_bytes = 0;
-    int err;
-
     int fd = open(filename, O_CREAT | O_WRONLY | O_TRUNC, OPEN_PERMS);
+
     if (fd == -1) {
         char err_msg[MAX_FILENAME_SIZE + 40];
-        sprintf(err_msg, "recv_file: Could not create/overwrite file "
-                         "with name '%s'", filename);
+        sprintf(err_msg, "%s: Could not create/overwrite file "
+                         "with name '%s'", callee, filename);
         perror(err_msg);
         exit(1);
     }
 
-    do {
-        recv_data(sd, &buf);
-        printf("Read %d bytes\n", buf.data_leng);
+    return fd;
+}
 
-        int bytes_written = write(fd, buf.buffer, buf.data_leng);
-        
-        if (bytes_written == -1) {
-            perror("recv_file: Unable to write to output file");
-            exit(1);
-        }
-        
-        if (bytes_written != buf.data_leng) {
-            fprintf(stderr, "recv_file: Number of bytes recv'd from "
-                            "socket does not match number of bytes "
-                            "written to file!\n"
-                            "    Recv'd: %d\n"
-                            "    Wrote:  %d\n",
-                            buf.data_leng, bytes_written);
-            exit(1);
-        }
-
-        total_bytes += bytes_written;
-
-    } while (buf.data_leng != 0);
-    
-
-    printf("Wrote %d bytes to output file '%s'\n", total_bytes, filename);
-    
-    err = close(fd);
-    if (err == -1) {
-        perror("An error occured while trying to close the output file");
+// Exits with error message if error occurs.
+// Pass the `callee` parameter the value `__func__` for better error info.
+static void safe_close(int fd, const char *callee)
+{
+    if (close(fd) == -1) {
+        char msg[100];
+        sprintf(msg, "%s: An error occured while trying to close the "
+                     "output file", callee);
+        perror(msg);
         exit(1);
     }
+}
+
+// Exits with error message if error occurs.
+// Pass the `callee` parameter the value `__func__` for better error info.
+static int safe_write(int fd, const char *buf, int count,
+                      const char* callee)
+{
+
+    int bytes_written = write(fd, buf, count);
+
+    if (bytes_written == -1) {
+        char msg[100];
+        sprintf(msg, "%s: Unable to write to output file", callee);
+        perror(msg);
+        safe_close(fd, __func__);
+        exit(1);
+    }
+    
+    if (bytes_written != count) {
+        fprintf(stderr,
+                "%s: Could not write all %d bytes to output file.\n"
+                "\tExpected: %d\n"
+                "\tWrote:    %d\n",
+                callee, count, count, bytes_written);
+        safe_close(fd, __func__);
+        exit(1);
+    }
+
+    return bytes_written;
+}
+
+
+void recv_file(int sd, char *filename, int file_size)
+{
+    struct data_msg buf;
+    int total_bytes = 0;
+
+    int fd = safe_open_for_write(filename, __func__);
+
+    while (1) {
+        recv_msg(sd, (union any_msg *) &buf, CMD_DATA);
+
+        if (buf.msg_type != CMD_DATA) {
+            fprintf(stderr, "recv_file: Unexpected msg type '%x'! "
+                    "Aborting file transfer.\n", buf.msg_type);
+            safe_close(fd, __func__);
+            exit(1);
+        }
+
+        if (buf.data_leng <= 0)
+            break;
+        
+        printf("Read %d bytes\n", buf.data_leng);
+
+        total_bytes += safe_write(fd, buf.buffer, buf.data_leng, __func__);
+    }
+
+    if (buf.data_leng < 0) {
+        errno = -buf.data_leng; // Overwrite errno in current process.
+        perror("recv_file: An error occurred while recv'ing data from "
+               "peer");
+        fprintf(stderr, "Aborting file transfer.\n");
+
+        // Delete output file (will happen when `fd` is closed).
+        if (remove(filename) == -1) {
+            perror("recv_file: Removal of incomplete output file failed");
+        }
+    }
+
+    printf("Wrote %d bytes to output file '%s'\n", total_bytes, filename);
+    safe_close(fd, __func__);
 }
 


### PR DESCRIPTION
Restructured {send,recv}_file to handle errors, replaced `extern errno` with header include, added more docs to proj.h